### PR TITLE
V0.2 alpha

### DIFF
--- a/LoadFileIngester.lpi
+++ b/LoadFileIngester.lpi
@@ -61,7 +61,6 @@
     </CodeGeneration>
     <Linking>
       <Debugging>
-        <GenerateDebugInfo Value="False"/>
         <DebugInfoType Value="dsDwarf2Set"/>
       </Debugging>
       <Options>

--- a/LoadFileIngester.lpr
+++ b/LoadFileIngester.lpr
@@ -54,10 +54,13 @@ uses
   windows,
   sysutils,
   dateutils,
-  contnrs;
+  contnrs,
+  FileUtil,
+  Zipper;        // To enable exploration of compound Office files
 
   const
     BufEvdNameLen=4096;
+    BufLen=2048;
 var
   // These are global vars
   MainWnd                  : THandle;
@@ -67,11 +70,14 @@ var
   TotalDataInBytes         : Int64;
   HasAParent               : integer;
   RunFolderBuilderAgain    : Boolean;
+  VerReleaseIsLessThan2000 : Boolean;
+  VerRelease2000OrAbove    : Boolean;
   intOutputLength          : integer;
   slOutput                 : TStringlist;
   HashType                 : Int64;
   StartTime, EndTime       : TDateTime;
-  TimeTaken                : string;
+  TimeTaken, TextificationOutputPath : string;
+  OutputSubFolderNative, OutputSubFolderText, OutputFolder : array[0..Buflen-1] of WideChar;
 
   // Evidence name is global for later filesave by name
   pBufEvdName              : array[0..BufEvdNameLen-1] of WideChar;
@@ -79,6 +85,8 @@ var
 // XT_Init : The first call needed by the X-Tension API. Must return 1 for the X-Tension to continue.
 function XT_Init(nVersion, nFlags: DWord; hMainWnd: THandle; lpReserved: Pointer): LongInt; stdcall; export;
 begin
+  VerReleaseIsLessThan2000 := false;
+  VerRelease2000OrAbove    := false;
   // Get high 2 bytes from nVersion
   VerRelease := Hi(nVersion);
   // Get 3rd high byte for service release. We dont need it yet but we might one day
@@ -92,23 +100,34 @@ begin
                         'Relativity LoadFile Generator', MB_ICONINFORMATION);
 
 
-    result := -1;
+    result := -1;  // Should abort and not run any further
   end
-  else
+  else  // If the version of XWF is less than v20.00 but greater than 18.9, continue but with advisory.
+    if (VerRelease > 1890) and (VerRelease < 2000) then
     begin
-      // Just make sure everything is initilised
-      TotalDataInBytes         := 0;
-      FillChar(pBufEvdName, SizeOf(pBufEvdName), $00);
+      VerReleaseIsLessThan2000 := true;
+      MessageBox(MainWnd, 'Warning: ' +
+                              ' Limited support for compound files (e.g. DOCX) available. Advise use of XWF v20.00+ ',
+                              'Relativity LoadFile Generator', MB_ICONINFORMATION);
 
-      // Check XWF is ready to go. 1 is normal mode, 2 is thread-safe. Using 1 for now
-      if Assigned(XWF_OutputMessage) then
-      begin
-        Result := 1; // lets go
-        MainWnd:= hMainWnd;
-      end
-      else Result := -1; // stop
+
+      result := 1;  // Continue, with warning accepted
     end;
+
+  // If the versioning is above 18.9, and regardless of whether it is less than v20.00 or higher, continue
+  VerRelease2000OrAbove := true;
+  TotalDataInBytes      := 0;
+  FillChar(pBufEvdName, SizeOf(pBufEvdName), $00);
+
+  // Check XWF is ready to go. 1 is normal mode, 2 is thread-safe. Using 1 for now
+  if Assigned(XWF_OutputMessage) then
+  begin
+    Result := 1; // lets go
+    MainWnd:= hMainWnd;
+  end
+  else Result := -1; // stop
 end;
+
 
 // FormatVersionRelease : Converts the "1980" style of version number to "19.8"
 // Returns version as string on success
@@ -173,13 +192,13 @@ end;
 // IsValidFilename : takes a filename string pointer and checks it does not contain
 // '/' or ':' or '*' or ? etc. i.e. Windows illegal filename chars. If it does,
 // it returns false. True otherwise
-function IsValidFilename(s : PWIDECHAR) : boolean;  stdcall; export;
+function IsValidFilename(s : unicodestring) : boolean;  stdcall; export;
 var
   i : integer;
 begin
   result := true;
 
-  for i := 0 to Length(s) do
+  for i := 1 to Length(s) do
    begin
      if ((s[i] = #34) or    // the quote char "
          (s[i] = #42) or    // the asterix *
@@ -197,20 +216,21 @@ begin
    end;
 end;
 
-// SanistiseFilename : iterates the PWideChar string and wherever an illegal char
+// SanistiseFilename : iterates the string and wherever an illegal char
 // is found, it is replaced with an underscore
-// It returns the new sanitised filename as a PWideChar or an empty PWideChar on failure.
-function SanitiseFilename(s : PWideChar) : PWideChar;
+// It returns the new sanitised filename or an empty string on failure.
+function SanitiseFilename(s : unicodestring) : unicodestring;
 const
   BufLen=2048;
 var
-  s2 : PWideChar;
+  s2 :  unicodestring;
   i : integer;
   Buf, Outputmessage : array[0..Buflen-1] of WideChar;
 begin
-  s2 := '';
-  // The PWideChar is an array, so to only itterate the actual chars, we use StrLen
-  for i := 0 to SysUtils.StrLen(s) do
+  // Make sure length of new sanatised string is equal to original string
+  SetLength(s2, length(s));
+
+  for i := 1 to Length(s) do
    begin
      if ((s[i] = #34) or    // the quote char "
          (s[i] = #42) or    // the asterix *
@@ -222,7 +242,7 @@ begin
          (s[i] = #124) or    // the pipe char |
          (s[i] = #92)) then // the backslash \
        begin
-         s2[i] := '_'
+         s2[i] := #95; // '_' char
        end
      else s2[i] := s[i];
    end;
@@ -282,6 +302,92 @@ begin
   Result := Result + FileTimeBase;
 end;
 
+function ExtractFileFromZip(ZipName : string) : string;
+var
+  UnZipper: TUnZipper;
+begin
+  result := '';
+  UnZipper := TUnZipper.Create;
+  try
+    UnZipper.FileName := ZipName;
+    UnZipper.OutputPath := TextificationOutputPath;
+    UnZipper.Examine;
+    UnZipper.UnZipAllFiles(ZipName);
+    if FileExists(Unzipper.OutputPath + '\word\' + 'document.xml') then
+      result := Unzipper.OutputPath + '\word\' + 'document.xml'
+    else
+      if FileExists(Unzipper.OutputPath + 'content.xml') then
+          result := Unzipper.OutputPath + 'content.xml'
+          else result := '';
+  finally
+    UnZipper.Free;
+  end;
+end;
+
+// GetOutputLocation : Open OutputLocation.txt and get the path from line 1 and
+// return that string. Returns empty string on failure
+function GetOutputLocation() : widestring; stdcall; export;
+const
+  C_FNAME = 'OutputLocation.txt';
+
+var
+  UserFile  : Text;
+  FileName,
+    TFile   : String;
+begin
+  result              := '';
+  intOutputLength     := 0;
+  FileName            := C_FNAME;
+
+  Assign(UserFile, FileName);
+  Reset(UserFile); { 'Reset' means open the file x and reset cursor to the beginning of file }
+  Repeat
+    Readln(UserFile,TFile);
+  Until Eof(UserFile);
+
+  // Get the length of the output path. We need this for later to make sure long filenames dont break Windows
+  intOutputLength := Length(TFile);
+  // Close the file
+  Close(UserFile);
+  // Switch the result to a UTF16 string for Windows and return that as result
+  result := UTF8ToUTF16(TFile);
+end;
+
+// CreateFolderStructure : CreateFolderStructure creates the output folders for the data to live in
+function CreateFolderStructure(RootOutputFolderName : array of widechar) : boolean; stdcall; export;
+const
+  BufLen=2048;
+var
+  Buf, outputmessage : array[0..Buflen-1] of WideChar;
+
+begin
+  result                := false;
+  OutputSubFolderNative := IncludeTrailingPathDelimiter(RootOutputFolderName) + 'NATIVE';
+  OutputSubFolderText   := IncludeTrailingPathDelimiter(RootOutputFolderName) + 'TEXT';
+
+  if not DirectoryExists(RootOutputFolderName) then
+    begin
+      CreateDir(RootOutputFolderName);
+    end;
+
+  if not DirectoryExists(OutputSubFolderNative) then
+    begin
+      CreateDir(OutputSubFolderNative);
+    end;
+
+  if not DirectoryExists(OutputSubFolderText) then
+    begin
+      CreateDir(OutputSubFolderText);
+    end;
+
+  outputmessage := 'Output folders created successfully : OK. Now processing files...';
+  lstrcpyw(Buf, outputmessage);
+  XWF_OutputMessage(@Buf[0], 0);
+
+  RunFolderBuilderAgain := false; // prevent execution of this function for remainder of file items
+  result := true;
+end;
+
 // Gets the case name, and currently selected evidence object, and the image size
 // and stores as a header for writing to HTML output later. Returns true on success. False otherwise.
 { Not currently used...
@@ -318,10 +424,11 @@ end;
 function XT_Prepare(hVolume, hEvidence : THandle; nOpType : DWord; lpReserved : Pointer) : integer; stdcall; export;
 var
   outputmessage, Buf  : array[0..MAX_PATH] of WideChar;
+  OutputFoldersCreatedOK : boolean;
 begin
   FillChar(outputmessage, Length(outputmessage), $00);
   FillChar(Buf, Length(Buf), $00);
-
+  OutputFoldersCreatedOK := false;
   HashType := -1;
   RunFolderBuilderAgain := true;
   if nOpType <> 4 then
@@ -393,73 +500,79 @@ begin
       finally
         // slOutput is freed and closed later
       end;
+
+      // To process compound Office documents, they are exported and then unzipped
+      // This will take place in C:\temp\compound. So we check that on launch of
+      // the X-Tension for use later.
+      // If the folder exists from previous runs, delete it and then re-create it.
+      // Or, create it if it does not exist to start with
+      try
+        if  VerReleaseIsLessThan2000 = true then
+        begin
+          if DirectoryExists('C:\temp\compound') = true then
+          begin
+            DeleteDirectory('C:\temp\compound', true);
+            if ForceDirectories('C:\temp\compound') then
+            begin
+              TextificationOutputPath := 'C:\temp\compound\';
+            end;
+          end
+          else
+          begin
+            ForceDirectories('C:\temp\compound');
+            TextificationOutputPath := 'C:\temp\compound\';
+          end;
+        end; // VersionRelease is 20.0 or higher, so no need for these folder
+      finally
+        // Nothing to finalise
+      end;
+
+      // Assign export locations for TEXT, IMAGES and a folder for NATIVE files
+      // as defined in the OutputLocation.txt file
+      OutputFolder          := GetOutputLocation;
+      if DirectoryExists(OutputFolder) = false then ForceDirectories(OutputFolder);
+      OutputFoldersCreatedOK:= CreateFolderStructure(OutputFolder);
+      if OutputFoldersCreatedOK then
+      begin
+        OutputSubFolderNative := IncludeTrailingPathDelimiter(OutputFolder) + 'NATIVE';
+        OutputSubFolderText   := IncludeTrailingPathDelimiter(OutputFolder) + 'TEXT';
+      end;
     end;
 end;
 
-// CreateFolderStructure : CreateFolderStructure creates the output folders for the data to live in
-function CreateFolderStructure(RootOutputFolderName : array of widechar) : boolean; stdcall; export;
-const
-  BufLen=2048;
+
+// Returns a buffer of textified data from an Input buffer
+function RunTextification(Buf : TBytes) : TBytes;
 var
-  Buf, OutputSubFolderNative, OutputSubFolderText,
-    outputmessage : array[0..Buflen-1] of WideChar;
-
-begin
-  result                := false;
-  OutputSubFolderNative := IncludeTrailingPathDelimiter(RootOutputFolderName) + 'NATIVE';
-  OutputSubFolderText   := IncludeTrailingPathDelimiter(RootOutputFolderName) + 'TEXT';
-
-  if not DirectoryExists(RootOutputFolderName) then
+  // 2 billion bytes is 2Gb, so unless user processes a docx > 2Gb, integer should be OK
+  i, j : integer;
+  OutputBytesBuffer : TBytes;
+  begin
+    j := 0;
+    SetLength(OutputBytesBuffer, Length(Buf));
+    // itterate the buffer looking for ASCII printables
+    for i := 0 to Length(Buf) - 1 do
     begin
-      CreateDir(RootOutputFolderName);
-    end;
-
-  if not DirectoryExists(OutputSubFolderNative) then
-    begin
-      CreateDir(OutputSubFolderNative);
-    end;
-
-  if not DirectoryExists(OutputSubFolderText) then
-    begin
-      CreateDir(OutputSubFolderText);
-    end;
-
-  outputmessage := 'Output folders created successfully : OK. Now processing files...';
-  lstrcpyw(Buf, outputmessage);
-  XWF_OutputMessage(@Buf[0], 0);
-
-  RunFolderBuilderAgain := false; // prevent execution of this function for remainder of file items
-  result := true;
-end;
-
-// GetOutputLocation : Open OutputLocation.txt and get the path from line 1 and
-// return that string. Returns empty string on failure
-function GetOutputLocation() : widestring; stdcall; export;
-const
-  C_FNAME = 'OutputLocation.txt';
-
-var
-  UserFile  : Text;
-  FileName,
-    TFile   : String;
-begin
-  result              := '';
-  intOutputLength     := 0;
-  FileName            := C_FNAME;
-
-  Assign(UserFile, FileName);
-  Reset(UserFile); { 'Reset' means open the file x and reset cursor to the beginning of file }
-  Repeat
-    Readln(UserFile,TFile);
-  Until Eof(UserFile);
-
-  // Get the length of the output path. We need this for later to make sure long filenames dont break Windows
-  intOutputLength := Length(TFile);
-  // Close the file
-  Close(UserFile);
-  // Switch the result to a UTF16 string for Windows and return that as result
-  result := UTF8ToUTF16(TFile);
-end;
+      if Buf[i] in [32..127] then
+        begin
+          OutputBytesBuffer[j] := Buf[i];
+          inc(j, 1);
+        end
+      else
+      if Buf[i] = 13 then
+        begin
+          OutputBytesBuffer[j] := Buf[i];
+          inc(j, 1);
+        end
+      else
+      if Buf[i] = 10 then
+        begin
+          OutputBytesBuffer[j] := Buf[i];
+          inc(j, 1);
+        end;
+      end; // buffer itteration ends
+    result := OutputBytesBuffer;
+  end;
 
 // XT_ProcessItem : Examines each item in the selected evidence object. The "type category" of the item
 // is then added to a string list for traversal later. Must return 0! -1 if fails.
@@ -467,73 +580,78 @@ function XT_ProcessItem(nItemID : LongWord; lpReserved : Pointer) : integer; std
 const
   BufLen=2048;
 var
-  // WideChar arrays
-  lpTypeDescr, Buf, OutputFolder, OutputSubFolderNative, OutputSubFolderText,
-    UniqueID, errormessage, TruncatedFilename: array[0..Buflen-1] of WideChar;
+  // WideChar arrays. More preferable on Windows UTF16 systems and better for Unicode chars
+  lpTypeDescr, lpTypeDescrOffice, Buf, OutputFolder,
+    UniqueID, errormessage, TruncatedFilename, strHashValue,
+    OutputLocationForNATIVE, OutputLocationForTEXT, JoinedFilePath,
+    JoinedFilePathAndName, OutputFileText,  strModifiedDateTime,
+    OfficeFileName, OutputLocationOfFile : array[0..Buflen-1] of WideChar;
 
   // 32-bit integers
-   itemtypeinfoflag, i, j, intBytesRead, parentCounter, intLengthOfOutputFolder,
+   itemtypeinfoflag, itemtypeinfoflagOfficeFile, intBytesRead, parentCounter, intLengthOfOutputFolder,
      intLengthOfFilename, WriteSuccess, intTotalOutputLength,
      intBreachValue                          : integer;
 
   // 64-bit integers
-  ItemSize, WriteSize, intModifiedDateTime   : Int64;
+  ItemSize, intModifiedDateTime   : Int64;
 
   // Plain Byte arrays, TBytes
-  InputBytesBuffer, OutputBytesBuffer              : TBytes; // using TBytes because it allows use of SetLength so we can enlarge or reduce depending on file size (i.e.ItemSize)
+  InputBytesBuffer, TextifiedBuffer          : TBytes; // using TBytes because it allows use of SetLength so we can enlarge or reduce depending on file size (i.e.ItemSize)
 
   // Handles
   hItem                                      : THandle;
 
   // Booleans
-  IsItAPicture, OutputFoldersCreatedOK, FilenameLegal, TruncatedFileFlag : boolean;
+  IsItAPicture, IsItAnOfficeFile, FilenameLegal, TruncatedFileFlag : boolean;
 
   // TFilestreams
-  OutputStreamNative, OutputStreamText       : TFileStream;
+  OutputStreamNative, OutputStreamText, temp_strm : TFileStream;
 
   // UTF8 BOM arrays
   UTF8BOM                                    : array[0..2] of byte = ($EF, $BB, $BF);
 
-  // WideChar Pointer arrays. Used a lot due to X-Ways and Windows using UTF16 a lot. XWF_GetFileName returns a pointer to a null terminated widechar. It decides what array to return
-  NativeFileName, ParentFileName, CorrectedFilename : PWideChar;
-
-  // Standard strings of unlimited length as defined by compiler directive at top, i.e. {$H+}
-  OutputLocationForNATIVE, OutputLocationForTEXT, JoinedFilePath,
-    JoinedFilePathAndName, OutputFileText, strHashValue, strModifiedDateTime : string;
-
-  // Unicode Strings. Essentially the same a widechar arrays. Probably change this later.
-  FileExtension : UnicodeString;
+  // PWideChar Pointer arrays are used a lot due to X-Ways and Windows using UTF16.
+  // XWF_GetFileName returns a pointer to a null terminated widechar. It decides what array to return
+  // However, using UnicodeStrings is more generally advised in FPC as memory handling is taken
+  // care of automatically by the compiler, thus avoiding the need for New() and Dispose()
+  NativeFileName, ParentFileName, CorrectedFilename, FileExtension : unicodestring;
 
 begin
   ItemSize               := -1;
   intBytesRead           := 0;
   intTotalOutputLength   := 0;
   intBreachValue         := 0;
-  OutputFoldersCreatedOK := false;
+  intModifiedDateTime    := 0;
 
   // Make sure buffers are empty and filled with zeroes
   // This explains why its done this way : https://forum.lazarus.freepascal.org/index.php?topic=13296.0
-  FillByte(lpTypeDescr[0],    Length(lpTypeDescr)*sizeof(lpTypeDescr[0]), 0);
+  FillByte(lpTypeDescr[0],       Length(lpTypeDescr)*sizeof(lpTypeDescr[0]), 0);
+  FillByte(lpTypeDescrOffice[0], Length(lpTypeDescrOffice)*sizeof(lpTypeDescrOffice[0]), 0);
   //FillByte(bufHashVal[0], Length(bufHashVal)*sizeof(bufHashVal[0]), 0);
+  JoinedFilePath          := '';
   JoinedFilePathAndName   := '';
   OutputLocationForNATIVE := '';
   OutputLocationForTEXT   := '';
   strHashValue            := '';
   strModifiedDateTime     := '';
-  intModifiedDateTime     := 0;
-  IsItAPicture            := false;
   TruncatedFilename       := '';
+  IsItAPicture            := false;
   TruncatedFileFlag       := false;
+  IsItAnOfficeFile        := false;
 
   // Get the size of the item
   ItemSize := XWF_GetItemSize(nItemID);
 
   if ItemSize > 0 then
   begin
+    // Keep track of how much data we process
     inc(TotalDataInBytes, ItemSize);
+
     // Make InputBytesBuffer big enough to hold file content
     SetLength(InputBytesBuffer, ItemSize);
-    SetLength(OutputBytesBuffer, ItemSize);
+
+    // Make the output text buffer big enough to hold the max file content (though it will always be less)
+    SetLength(TextifiedBuffer, ItemSize);
 
     // For every item, check the type status. We also collect the category (0x4000000)
     // though we do not use it in this X-Tension, yet, as we are exporting selected files
@@ -554,44 +672,33 @@ begin
         // Get the nano second Windows FILETIME date of the modified date value for the item
         intModifiedDateTime := XWF_GetItemInformation(nItemID,  XWF_ITEM_INFO_MODIFICATIONTIME, nil);
 
-        // Convert the date to human readable using bespoke function FileTimeToDateTime
-        strModifiedDateTime := FormatDateTime('DD/MM/YYYY HH:MM:SS', FileTimeToDateTime(intModifiedDateTime));
+        // Convert the date (if there is one) to human readable using bespoke function FileTimeToDateTime
+        if intModifiedDateTime > 0 then
+        begin
+          strModifiedDateTime := FormatDateTime('DD/MM/YYYY HH:MM:SS', FileTimeToDateTime(intModifiedDateTime));
+        end;
 
         // Open the file item. Returns 0 if item ID could not be opened.
         hItem := XWF_OpenItem(CurrentVolume, nItemID, $01);
         if hItem > 0 then
         begin
-          // Read the file item
-          intBytesRead := XWF_Read(hItem, 0, @InputBytesBuffer[0], ItemSize);
-
-          // Get the file item name and path
+          // Get the file item name and path, if one exists
           NativeFileName := XWF_GetItemName(nItemID);
-          parentCounter  := XWF_GetItemParent(nItemID);
-          HasAParent     := 0;
-          repeat
-            HasAParent := XWF_GetItemParent(parentCounter);
-            if HasAParent > -1 then
+          if NativeFileName <> NULL then
             begin
-              parentCounter  := HasAParent;
-              ParentFileName := XWF_GetItemName(HasAParent);
-              JoinedFilePath := IncludeTrailingPathDelimiter(ParentFileName) + JoinedFilePath;
+              parentCounter  := XWF_GetItemParent(nItemID);
+              HasAParent     := 0;
+              repeat
+                HasAParent := XWF_GetItemParent(parentCounter);
+                if HasAParent > -1 then
+                begin
+                  parentCounter  := HasAParent;
+                  ParentFileName := XWF_GetItemName(HasAParent);
+                  JoinedFilePath := IncludeTrailingPathDelimiter(ParentFileName) + JoinedFilePath;
+                end;
+              until HasAParent = -1;
+              JoinedFilePathAndName := JoinedFilePath + NativeFileName; // Not needed, yet. But might do in future.
             end;
-          until HasAParent = -1;
-          JoinedFilePathAndName := JoinedFilePath + NativeFileName; // Not needed, yet. But might do in future.
-
-          // Assign export locations for TEXT, IMAGES and a folder for NATIVE files
-          // as defined in the OutputLocation.txt file
-          OutputFolder          := GetOutputLocation;
-          if DirectoryExists(OutputFolder) = false then ForceDirectories(OutputFolder);
-          OutputSubFolderNative := IncludeTrailingPathDelimiter(OutputFolder) + 'NATIVE';
-          OutputSubFolderText   := IncludeTrailingPathDelimiter(OutputFolder) + 'TEXT';
-
-          // Create export locations but only if it hasn't already been done.
-          // No point re-checking creation status for every item.
-          if RunFolderBuilderAgain = true then
-          begin
-            OutputFoldersCreatedOK := CreateFolderStructure(OutputFolder);
-          end;
 
           // Get the UniqueID for each item processed based on ItemID from XWF case.
           // Note this does not include the partition prefix. Example :
@@ -613,11 +720,14 @@ begin
 
           // Calculate the path and filename lengths
           // First, get the length of the Unique ID and Filename
-          intLengthOfFilename     := SysUtils.StrLen(UniqueID) + SysUtils.StrLen(NativeFilename);
+          intLengthOfFilename     := SysUtils.StrLen(UniqueID) + Length(NativeFilename);
+
           // Second, compute the length of the output folder length, including the "NATIVE" sub dir
           intLengthOfOutputFolder := intOutputLength + SysUtils.StrLen(OutputSubFolderNATIVE);
+
           // Third, add these first two values together to get a combined length
           intTotalOutputLength    := intLengthOfFilename + intLengthOfOutputFolder;
+
           // Now, if thats over 255, work out how much over 255 the combined length is
           // and truncate it by that amount, called the BreachValue
           if intTotalOutputLength > 255 then
@@ -632,12 +742,14 @@ begin
           end;
 
           // Export the original (aka native) file to the output folder, and that might be a shorter version than original
+
           try
             OutputStreamNative := nil;
             if (FilenameLegal = true) and (TruncatedFileFlag = false) then
             begin
               try
               OutputStreamNative := TFileStreamUTF8.Create(IncludeTrailingPathDelimiter(OutputSubFolderNATIVE) + UniqueID+'-'+ UTF16toUTF8(NativeFileName), fmCreate);
+              OutputLocationOfFile := IncludeTrailingPathDelimiter(OutputSubFolderNATIVE) + UniqueID+'-'+ UTF16toUTF8(NativeFileName);
               except
                 on E: EFOpenError do
                 begin
@@ -653,6 +765,7 @@ begin
             begin
               try
               OutputStreamNative := TFileStreamUTF8.Create(IncludeTrailingPathDelimiter(OutputSubFolderNATIVE) + UniqueID+'-'+UTF16toUTF8(CorrectedFilename), fmCreate);
+              OutputLocationOfFile := IncludeTrailingPathDelimiter(OutputSubFolderNATIVE) + UniqueID+'-'+UTF16toUTF8(CorrectedFilename);
               except
                 on E: EFOpenError do
                   begin
@@ -668,6 +781,7 @@ begin
             begin
               try
               OutputStreamNative := TFileStreamUTF8.Create(IncludeTrailingPathDelimiter(OutputSubFolderNATIVE) + UniqueID+'-'+UTF16toUTF8(TruncatedFileName), fmCreate);
+              OutputLocationOfFile := IncludeTrailingPathDelimiter(OutputSubFolderNATIVE) + UniqueID+'-'+UTF16toUTF8(TruncatedFileName);
               except
                 on E: EFOpenError do
                 begin
@@ -679,6 +793,9 @@ begin
               OutputLocationForNATIVE := '.\NATIVE\' + UniqueID+'-'+UTF16toUTF8(TruncatedFilename);
             end;
 
+            // Read the native file item to buffer
+            intBytesRead := XWF_Read(hItem, 0, @InputBytesBuffer[0], ItemSize);
+            // Write the native file out to disk using the above declared stream
             WriteSuccess := -1;
             WriteSuccess := OutputStreamNative.Write(InputBytesBuffer[0], ItemSize);
             if WriteSuccess = -1 then
@@ -700,41 +817,53 @@ begin
           end
           else IsItAPicture := false;
 
-          // TODO TedSmith : Add decompression library for
-          //  * MS Office and
-          //  * LibreOffice files and
-          //  * Adobe PDF files
-
-          // If item is not a picture file, textify it.
-          if IsItAPicture = false then
+          // ======== VERSIONS OF XWF < v20.0 ============================================
+          // Due to XWF_OpenItem in versions less than v20.0 not having a text based handle option
+          // we do not have the ability to get the users view of Office and other compressed
+          // file types. So, we have to manually export, decompress, and then read them,
+          // including the XML schemas. So this section handles that specifically as best we can.
+          if VerReleaseIsLessThan2000 = true then
           begin
-            // if its not a picture file...textify it and then export it as text
-            j := 0;
-            WriteSize := 0;
-            // itterate the buffer looking for ASCII printables
-            for i := 0 to Length(InputBytesBuffer) - 1 do
+          // Now do a different type lookup, using file extension instead of category
+          // to see if it is a docx or odt type file
+          // If it is such a file, unzip it to get the document.xml extracted to
+          // temporary location. Then read that, instead of the compressed DOCX native file
+
+            itemtypeinfoflagOfficeFile := XWF_GetItemType(nItemID, @lpTypeDescrOffice, Length(lpTypeDescrOffice) or $20000000);
+            // If an Office type descriptor was retrieved, unzip it and read it
+            if lpTypeDescrOffice <> #0 then
             begin
-              if InputBytesBuffer[i] in [32..127] then
-                begin
-                  OutputBytesBuffer[j] := InputBytesBuffer[i];
-                  inc(WriteSize,1);
-                  inc(j, 1);
-                end
-              else
-              if InputBytesBuffer[i] = 13 then
-                begin
-                  OutputBytesBuffer[j] := InputBytesBuffer[i];
-                  inc(WriteSize,1);
-                  inc(j, 1);
-                end
-              else
-              if InputBytesBuffer[i] = 10 then
-                begin
-                  OutputBytesBuffer[j] := InputBytesBuffer[i];
-                  inc(WriteSize,1);
-                  inc(j, 1);
+              if (lpTypeDescrOffice = 'MS Word 2007') or (lpTypeDescrOffice = 'OpenOffice Writer') then
+              begin
+               IsItAnOfficeFile := true
+              end
+              else IsItAnOfficeFile := false;
+
+              if IsItAnOfficeFile then
+              begin
+                // Unzip the compound file and get the path to "\word\document.xml" (Word) or "content.xml" (Libreoffice)
+                OfficeFileName := ExtractFileFromZip(OutputLocationOfFile);
+                // Read the appropriate.xml from the docx or odt file and store its content in InputBytesBuffer
+                // This obviously replaces anything already in the buffer from the initial read
+                // TODO : Work out how to do the read only once rather than twice when a compound file
+                temp_strm := TFileStream.Create(OfficeFileName, fmOpenRead or fmShareDenyWrite);
+                try
+                  SetLength(InputBytesBuffer, temp_strm.Size);
+                  temp_strm.Read(InputBytesBuffer[1], temp_strm.Size);
+                finally
+                  temp_strm.Free;
                 end;
-              end; // buffer itteration ends
+              end;
+            end; // End of if lpTypeDescrOffice <> #0 then
+
+            // Now carry on as normal, doing the textification work
+
+            // If item is not a picture file, and if item is a DOCx file, textify it.
+            if (IsItAPicture = false) or (IsItAnOfficeFile = true) then
+            begin
+              // if its not a picture file and it is a compound file...textify it and then export it as text
+
+              TextifiedBuffer := RunTextification(InputBytesBuffer);
 
               if (FilenameLegal = true) and (TruncatedFileFlag = false) then
               begin
@@ -765,7 +894,7 @@ begin
                 end;
                 OutputStreamText.Write(UTF8BOM[0],3);
                 WriteSuccess := -1;
-                WriteSuccess := OutputStreamText.Write(OutputBytesBuffer[0], WriteSize);
+                WriteSuccess := OutputStreamText.Write(TextifiedBuffer[0], Length(TextifiedBuffer));
                 if WriteSuccess = -1 then
                 begin
                   errormessage := 'ERROR : ' + UniqueID+'-'+NativeFileName + '.txt' + ' could not be written to disk. TextStream write error.';
@@ -778,13 +907,92 @@ begin
                 OutputLocationForTEXT := '.\TEXT\' + OutputFileText;
               end;
             end; // text file check and export ends
-
-            // Populate the loadfile, using Unicode TAB character value. Not comma, because sometimes e-mail attachments contain comma in the name
-            slOutput.Add(UniqueID+#09+NativeFileName+#09+JoinedFilePath+#09+OutputLocationForTEXT+#09+OutputLocationForNATIVE+#09+strHashValue+#09+strModifiedDateTime);
-
           // Close the original file handle
           XWF_Close(hItem);
-        end; // end of XWF_OpenItem
+          end // End of pre XWF v20.0 behaviour
+          else
+          // ======== VERSIONS OF XWF => v20.0 ===========================================
+          // Due to the new text based handle of XWF_OpenItem in v20.0, we get a handle to
+          // the users view of Office and other compressed file types. As all the filename
+          // business has been handled above already, all we have to do is release the
+          // existing handle, get a new text based one, read the content and write it out
+          // And as before, if it is a Picture file, don't try and textifiy. Its already
+          // been written out to disk.
+          if (VerRelease2000OrAbove = true) and (IsItAPicture = false) then
+          begin
+            // Get new text based handle to itemID, if one can be obtained, i.e. not encrypted etc
+            hItem := XWF_OpenItem(CurrentVolume, nItemID, $400);
+            if hItem > 0 then
+            begin
+              // Get size of the text file associated with the handle, not size of original (nItemID) file
+              // Note use of XWF_GetSize, and not XWF_GetItemSize
+              // This will give us the size of the text value of the file, not the size of the original file
+
+              ItemSize := -1;
+              ItemSize := XWF_GetSize(hItem, nil);
+
+              // Read the native file item as text to buffer
+              if ItemSize > -1 then
+              begin
+                intBytesRead := XWF_Read(hItem, 0, @InputBytesBuffer[0], ItemSize);
+
+                // Format the filenames of the text formatted output files to ensure filesystem suitability
+                if (FilenameLegal = true) and (TruncatedFileFlag = false) then
+                begin
+                  OutputFileText := UniqueID+'-'+UTF16toUTF8(NativeFileName) + '.txt';
+                end
+                else
+                if FilenameLegal = false then
+                begin
+                  OutputFileText := UniqueID+'-'+UTF16toUTF8(CorrectedFilename) + '.txt';
+                end
+                else
+                if TruncatedFileFlag = true then
+                begin
+                  OutputFileText := UniqueID+'-'+UTF16toUTF8(TruncatedFilename) + '.txt';
+                end;
+
+                // Write the text to files on disk, named accordingly
+                try
+                  OutputStreamText := nil;
+                  try
+                    OutputStreamText := TFileStreamUTF8.Create(IncludeTrailingPathDelimiter(OutputSubFolderText) + OutputFileText, fmCreate);
+                  except
+                    on E: EFOpenError do
+                      begin
+                        errormessage := 'ERROR : Could not create textified filestream of native fie ' + OutputFileText + ', ' + E.Message;
+                        lstrcpyw(Buf, errorMessage);
+                        XWF_OutputMessage(@Buf[0], 0);
+                      end;
+                  end;
+                  OutputStreamText.Write(UTF8BOM[0],3);
+                  WriteSuccess := -1;
+                  WriteSuccess := OutputStreamText.Write(InputBytesBuffer[0], ItemSize);
+                  if WriteSuccess = -1 then
+                  begin
+                    errormessage := 'ERROR : ' + UniqueID+'-'+NativeFileName + '.txt' + ' could not be written to disk. TextStream write error.';
+                    lstrcpyw(Buf, errormessage);
+                    XWF_OutputMessage(@Buf[0], 0);
+                  end;
+                finally
+                  OutputStreamText.Free;
+                  // Define the outputs of the files for the load file itself
+                  OutputLocationForTEXT := '.\TEXT\' + OutputFileText;
+                end; // end of write text try statement
+              end; // End of ItemSize valid
+            end // End of valid handle check : if hItem > 0 etc. If the handle failed, warn the user
+            else
+            begin // Alert the user that a viewer component view of the file could not be painted
+              errormessage := 'ERROR : ' + UniqueID+'-'+NativeFileName + '.txt' + ' could not be written because a text based viewer component read of it cannot be obtained. Encrypted? Corrupt?';
+              lstrcpyw(Buf, errormessage);
+              XWF_OutputMessage(@Buf[0], 0);
+            end;
+          end; // And of Version 20+ specific actions and end of 2nd XWF_OpenItem call
+
+          // Finalise output to the Loadfile for this Item
+          // Populate the loadfile, using Unicode TAB character value. Not comma, because sometimes e-mail attachments contain comma in the name
+          slOutput.Add(UniqueID+#09+NativeFileName+#09+JoinedFilePath+#09+OutputLocationForTEXT+#09+OutputLocationForNATIVE+#09+strHashValue+#09+strModifiedDateTime);
+        end; // end of first XWF_OpenItem
       end; // end of item type flags check
     end; // end of description check
   end; // end of itemsize check

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ###  *** Requirements ***
   This X-Tension is designed for use only with X-Ways Forensics.
-  This X-Tension is designed for use only with v18.9 or later (due to file category lookup).
+  This X-Tension is designed for use only with v18.9 or later (due to file category lookup), and ideally v20.0+.
   This X-Tension is not designed for use on Linux or OSX platforms.
   The case must have either MD5, SHA-1 or SHA256 hash algorithms computed.
   There is a compiled 32 and 64 bit version of the X-Tension to be used with the corresponding version of X-Ways Forensics. 
@@ -23,10 +23,8 @@
   Upon completion, the output can be injested into Relativity.
 
 ###  TODOs
-   // TODO TedSmith : Add a decompression library for
-    * MS Office and
-    * LibreOffice files and
-    * Adobe PDF files
+   // TODO TedSmith : Further develop decompression of more compound files for XWF users older than v20.0
+   // DOCX and ODT added to v0.2 Alpha. Adobe PDF files, and XLSX files still to do
    // TODO TedSmith : Fix parent object lookup for items embedded in another object
      where the actual file parent seems to be being skipped, even if the remaining path is not.
    // TODO Ted Smith : Write user manual

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,12 @@
 RELEASE NOTES
 =============
 
+May 5th 2020
+Compound office files are now unzipped to the users default temp area (C:\Users\UserName\AppData\Local\Temp\XWF_2_RT_Temp) instead of C:\Temp to avoid filesystem permission issues. 
+If file handle assignment fails for any given item as either native file or text file, an output error detailing the item name or ID is shown in messages window
+The UniqueID, as reported exactly in XWF is now reported fully, instead of just the ItemID within the context of the partition. So previously, item with ID "1234" was reported as "1234" but if it is
+in partition 1, the casewide UniqueID is "1-1234", and it is that which is now reported instead of "1234". 
+
 Apr 22, 2020
 Initial creation of new branch, v02-Alpha. 
 Functionality as before, but with new additions. 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,0 +1,22 @@
+RELEASE NOTES
+=============
+
+Apr 22, 2020
+Initial creation of new branch, v02-Alpha. 
+Functionality as before, but with new additions. 
+If used with versions of XWF between 18.9 and v19.9, compressed MS Office documents that using the docx format will be temporarily exported, unzipped, and the content of document.xml textified
+If used with versions of XWF between 18.9 and v19.9, compressed LibreOffice Writer documents that use the odt format will be temporarily exported, unzipped, and the content of content.xml textified
+If used with versions of XWF between 20.0+, the X-Tension utilises the new flag of XWF_OpenItem ("0x0400 = extrain plain text on the fly and open textual data (v20.0 and later, useful for certain 
+supported file formats)" that allows a text based handle to the file object. As such, that view is exported as the text file, and the textification routine is skipped. 
+PWideChar variables switched to UnicodeString types for better memory management
+
+Depends on the use of XWF v18.9 or above, ideally v20.0 or above. 
+
+Nov 27, 2019
+Initial release of v01-Alpha. 
+Current functionality : Enables users to select one or more files in the Directory Browser of X-Ways Forensics, and upon execution of the X-Tension (DLL), it will 
+1) export the selected files to a NATIVE folder in the output location
+2) export the selected files as text to a TEXT folder in the output location
+3) Create a TSV loadfile containing the original filename and path, the filenames and paths of their exported locations, and include some metadata such as Modified Date, hash value etc. 
+
+Depends on the use of XWF v18.9 or above


### PR DESCRIPTION
May 5th 2020
Compound office files are now unzipped to the users default temp area (C:\Users\UserName\AppData\Local\Temp\XWF_2_RT_Temp) instead of C:\Temp to avoid filesystem permission issues. 
If file handle assignment fails for any given item as either native file or text file, an output error detailing the item name or ID is shown in messages window
The UniqueID, as reported exactly in XWF is now reported fully, instead of just the ItemID within the context of the partition. So previously, item with ID "1234" was reported as "1234" but if it is
in partition 1, the casewide UniqueID is "1-1234", and it is that which is now reported instead of "1234". 

Apr 22, 2020
Initial creation of new branch, v02-Alpha. 
Functionality as before, but with new additions. 
If used with versions of XWF between 18.9 and v19.9, compressed MS Office documents that using the docx format will be temporarily exported, unzipped, and the content of document.xml textified
If used with versions of XWF between 18.9 and v19.9, compressed LibreOffice Writer documents that use the odt format will be temporarily exported, unzipped, and the content of content.xml textified
If used with versions of XWF between 20.0+, the X-Tension utilises the new flag of XWF_OpenItem ("0x0400 = extrain plain text on the fly and open textual data (v20.0 and later, useful for certain 
supported file formats)" that allows a text based handle to the file object. As such, that view is exported as the text file, and the textification routine is skipped. 
PWideChar variables switched to UnicodeString types for better memory management

Depends on the use of XWF v18.9 or above, ideally v20.0 or above. 